### PR TITLE
Add log line to indicate starAdd log line to indicate start of student test flowt of student test flow

### DIFF
--- a/tests/test_students_independents.py
+++ b/tests/test_students_independents.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 with open("tests/students.json", encoding="utf-8") as f:
     students = json.load(f)
 
+logger.info("🏗️ Starting independent student test flow")
 @pytest.mark.parametrize("student_data", students)
 def test_independent_student_flow(student_data):
     """


### PR DESCRIPTION
Added a logger.info() call at the beginning of the test_independent_student_flow function.
This helps to identify when each test starts in the logs, improving readability and debugging.